### PR TITLE
Add waveform control webpage with UDP signal mappings

### DIFF
--- a/Client Interface/main.py
+++ b/Client Interface/main.py
@@ -56,7 +56,11 @@ SIGNAL_MAP = {
     "mode_set": 0x08, "inter_enable": 0x09, "extern_enable": 0x0A,
     "warn_lamp": 0x0B, "ps_disable": 0x0C, "pwm_enable": 0x0D, "pwm_reset": 0x0E,
     "output_enable": 0x0F,
-    "SW_GET_VERSION": 0x01
+    "SW_GET_VERSION": 0x01,
+    "t1": 0x13, "th": 0x14, "t2": 0x15,
+    "a1": 0x16, "b1": 0x17, "c1": 0x18, "d1": 0x19,
+    "a2": 0x20, "b2": 0x21, "c2": 0x23, "d2": 0x24,
+    "run_current_wave": 0x25
 }
 SIGNAL_ID_TO_NAME = {v: k for k, v in SIGNAL_MAP.items()}
 LATEST_VALUES = {}
@@ -303,6 +307,13 @@ def api_upload_config():
         return jsonify({"status": "saved"})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+
+
+
+@app.route("/waveform")
+def waveform_page():
+    """Simple page for editing waveform parameters."""
+    return render_template("waveform.html")
 
 
 

--- a/Client Interface/templates/waveform.html
+++ b/Client Interface/templates/waveform.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Waveform Control</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    label { display:block; margin-top:0.5rem; }
+    input { width: 6rem; }
+    button { margin-top:1rem; }
+  </style>
+</head>
+<body>
+  <h1>Waveform Parameters</h1>
+  <div id="controls">
+    <label>t1: <input id="t1" type="number" step="0.01"></label>
+    <label>th: <input id="th" type="number" step="0.01"></label>
+    <label>t2: <input id="t2" type="number" step="0.01"></label>
+    <label>a1: <input id="a1" type="number" step="0.01"></label>
+    <label>b1: <input id="b1" type="number" step="0.01"></label>
+    <label>c1: <input id="c1" type="number" step="0.01"></label>
+    <label>d1: <input id="d1" type="number" step="0.01"></label>
+    <label>a2: <input id="a2" type="number" step="0.01"></label>
+    <label>b2: <input id="b2" type="number" step="0.01"></label>
+    <label>c2: <input id="c2" type="number" step="0.01"></label>
+    <label>d2: <input id="d2" type="number" step="0.01"></label>
+  </div>
+  <button id="send">Send Values</button>
+  <button id="run">Run Current Wave</button>
+
+  <script>
+  const names = ["t1","th","t2","a1","b1","c1","d1","a2","b2","c2","d2"];
+
+  function sendCommand(name, value){
+    fetch('/api/command',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({name:name, value: value})
+    });
+  }
+
+  document.getElementById('send').addEventListener('click', () => {
+    names.forEach(n => {
+      const val = parseFloat(document.getElementById(n).value || '0');
+      sendCommand(n, val);
+    });
+  });
+
+  document.getElementById('run').addEventListener('click', () => {
+    sendCommand('run_current_wave', 1);
+  });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- map waveform control signals (t1/th/etc.) to UDP IDs
- serve a simple waveform control page for editing parameters

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c78d1fe31c8324bc5cbbb01f0db073