### PR TITLE
Add waveform parameters link on UDP webpage

### DIFF
--- a/Client Interface/templates/index.html
+++ b/Client Interface/templates/index.html
@@ -101,6 +101,7 @@
   <header>
     <h1 id="title">Loading Control Panel...</h1>
     <div id="mode-indicator">Mode: Connecting...</div>
+    <a href="http://0.0.0.0:8009/waveform" class="btn-command" data-mode="get" style="margin-top: 1rem; display: inline-block;">Edit Waveform Parameters</a>
   </header>
   
   <main class="container">


### PR DESCRIPTION
## Summary
- Add "Edit Waveform Parameters" button on the UDP control panel to navigate to the waveform editor.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c790af7cc483248fa4def99225c7cc