### PR TITLE
Clarify dashboard status overview for Portenta targets

### DIFF
--- a/Client Interface/main.py
+++ b/Client Interface/main.py
@@ -11,6 +11,7 @@ import json
 import time
 import os
 import webbrowser
+from typing import Iterable, List, Optional
 
 eventlet.monkey_patch()
 # Path where uploaded configs will be stored
@@ -20,18 +21,38 @@ app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode='eventlet')
 
 
-# --- Broadcast Deduplication Setup ---
-last_values = {}
+# --- Device Configuration ---
+DEVICES = {
+    "ci1": {"label": "C&I 1", "ip": "192.168.1.212"},
+    "ci2": {"label": "C&I 2", "ip": "192.168.1.211"},
+    "ci3": {"label": "C&I 3", "ip": "192.168.1.203"},
+    "ci4": {"label": "C&I 4", "ip": "192.168.1.213"},
+    "ci5": {"label": "C&I 5", "ip": "192.168.1.214"},
+    "ci6": {"label": "C&I 6", "ip": "192.168.1.208"},
+}
+IP_TO_DEVICE = {info["ip"]: dev_id for dev_id, info in DEVICES.items()}
 
-def handle_incoming_signal(name, value):
-    global last_values
-    if name not in last_values or last_values[name] != value:
-        last_values[name] = value
-        print(f"[UDP] Broadcast: {name}={value}")
-        socketio.emit("update_value", {"name": name, "value": value})
+
+def resolve_target_ips(target_ids: Optional[Iterable[str]]) -> List[str]:
+    """Return a list of unique IPs for the requested target device IDs."""
+    if target_ids is None:
+        return [info["ip"] for info in DEVICES.values()]
+
+    ips: List[str] = []
+    for target in target_ids:
+        info = DEVICES.get(target)
+        if info:
+            ip = info["ip"]
+            if ip not in ips:
+                ips.append(ip)
+    return ips
+
+
+def device_label(device_id: str) -> str:
+    info = DEVICES.get(device_id)
+    return info["label"] if info else device_id
 
 # --- NEW: Updated Network and Protocol Configuration ---
-PORTENTA_IP = "192.168.3.55"  # Portenta IP
 PORTENTA_PORT = 17751  # The NEW fixed port for the bridge server
 
 LOCAL_PORT = 10006
@@ -61,7 +82,7 @@ SIGNAL_MAP = {
     "c1": 0x18, "d1": 0x19, "a2": 0x20, "b2": 0x21, "c2": 0x22, "d2": 0x23, "run_current_wave": 0x24, "internal_temperature": 0x25
 }
 SIGNAL_ID_TO_NAME = {v: k for k, v in SIGNAL_MAP.items()}
-LATEST_VALUES = {}
+LATEST_VALUES = {device_id: {} for device_id in DEVICES}
 
 
 # --- NEW: Updated Packet Signature Functions ---
@@ -80,23 +101,6 @@ def _calc_binary_sign(data: bytes) -> bytes:
     """Signature function for raw binary packets (used for encoding commands)."""
     # This matches the new rule: SHA256(first 10 bytes + key)
     return hashlib.sha256(data + DEFAULT_KEY).digest()[-4:]
-
-
-def handle_udp_ack_packet(packet: bytes):
-    """Handles 14-byte ACK packets and emits value updates via Socket.IO."""
-    if len(packet) != 14 or packet[5] != 0xA0:
-        return
-
-    sig_id = packet[4]
-    value = struct.unpack('>f', packet[6:10])[0]
-    name = SIGNAL_ID_TO_NAME.get(sig_id)
-
-    if name:
-        prev = LATEST_VALUES.get(name)
-        if prev != value:
-            LATEST_VALUES[name] = value
-            print(f"[UDP] ACK 0xA0: {name} changed {prev} → {value}")
-            socketio.emit("update_value", {"name": name, "value": value})
 
 
 def decode_json_packet(packet: bytes):
@@ -126,6 +130,13 @@ def udp_listener_thread():
     while True:
         try:
             data, addr = udp_sock.recvfrom(8192)
+            src_ip = addr[0]
+            device_id = IP_TO_DEVICE.get(src_ip)
+            if not device_id:
+                print(f"[UDP] ⚠ Received packet from unknown device {src_ip}")
+                continue
+
+            device_values = LATEST_VALUES.setdefault(device_id, {})
             if len(data) == 14:
                 payload_bytes = data[:10]
                 signature = data[10:14]
@@ -144,23 +155,41 @@ def udp_listener_thread():
                     print(f"[UDP] ⚠ Unknown sig_id=0x{sig_id:02X}")
                     continue
 
-                prev = LATEST_VALUES.get(name)
+                prev = device_values.get(name)
                 if sig_type == 0xA0:  # ACK_OK → treat as update
                     if prev != value:
-                        LATEST_VALUES[name] = value
-                        print(f"[UDP] ✅ ACK 0xA0: {name} changed {prev} → {value}")
-                        print(f"[WS]   → Emitting to clients: update_value = {{ name: {name}, value: {value} }}")
-                        socketio.emit("update_value", {"name": name, "value": value})
-                        print(f"[EMIT] update_value → name: {name}, value: {value}")
+                        device_values[name] = value
+                        print(f"[UDP] ✅ ACK 0xA0 ({device_id}): {name} changed {prev} → {value}")
+                        print(f"[WS]   → Emitting to clients: update_value = {{ device: {device_id}, name: {name}, value: {value} }}")
+                        socketio.emit(
+                            "update_value",
+                            {
+                                "device": device_id,
+                                "device_label": device_label(device_id),
+                                "ip": src_ip,
+                                "name": name,
+                                "value": value,
+                            },
+                        )
+                        print(f"[EMIT] update_value → device: {device_id}, name: {name}, value: {value}")
                     else:
-                        print(f"[UDP] ACK 0xA0: {name} unchanged at {value}")
+                        print(f"[UDP] ACK 0xA0 ({device_id}): {name} unchanged at {value}")
                 else:
                     if prev != value:
-                        LATEST_VALUES[name] = value
-                        print(f"[UDP] 🔁 {name} changed: {prev} → {value}")
-                        print(f"[WS]   → Emitting to clients: update_value = {{ name: {name}, value: {value} }}")
-                        socketio.emit("update_value", {"name": name, "value": value})
-                        print(f"[EMIT] update_value → name: {name}, value: {value}")
+                        device_values[name] = value
+                        print(f"[UDP] 🔁 {name} ({device_id}) changed: {prev} → {value}")
+                        print(f"[WS]   → Emitting to clients: update_value = {{ device: {device_id}, name: {name}, value: {value} }}")
+                        socketio.emit(
+                            "update_value",
+                            {
+                                "device": device_id,
+                                "device_label": device_label(device_id),
+                                "ip": src_ip,
+                                "name": name,
+                                "value": value,
+                            },
+                        )
+                        print(f"[EMIT] update_value → device: {device_id}, name: {name}, value: {value}")
             else:
                 try:
                     msg = json.loads(data.decode())
@@ -176,7 +205,7 @@ def udp_listener_thread():
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", devices=DEVICES)
 
 
 @app.route("/builder")
@@ -189,12 +218,32 @@ def builder():
 def handle_connect():
     """Send the latest known values to a newly connected client."""
     print(f"[SOCKETIO] Client connected: {request.sid}. Sending initial values")
-    for name, value in LATEST_VALUES.items():
-        emit("update_value", {"name": name, "value": value})
+    for device_id, values in LATEST_VALUES.items():
+        for name, value in values.items():
+            emit(
+                "update_value",
+                {
+                    "device": device_id,
+                    "device_label": device_label(device_id),
+                    "ip": DEVICES.get(device_id, {}).get("ip"),
+                    "name": name,
+                    "value": value,
+                },
+            )
 
 @app.route("/api/get_config", methods=["GET"])
 def api_get_config():
     """Request the display configuration from the Portenta."""
+    target_device = request.args.get("device")
+    if target_device:
+        target_ids: Optional[List[str]] = [target_device]
+    else:
+        target_ids = None
+    target_ips = resolve_target_ips(target_ids)
+    if not target_ips:
+        return jsonify({"error": "no valid device targets"}), 400
+
+    target_ip = target_ips[0]
     uid = os.urandom(4)
     payload = uid + bytes([0x00, 0x21]) + CONFIG_KEY
     sign = _calc_binary_sign(payload)
@@ -208,7 +257,7 @@ def api_get_config():
         cfg_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         cfg_sock.bind(("", CONFIG_LOCAL_PORT))  # Use a dedicated source port
         cfg_sock.settimeout(0.5)
-        cfg_sock.sendto(packet, (PORTENTA_IP, PORTENTA_PORT))
+        cfg_sock.sendto(packet, (target_ip, PORTENTA_PORT))
 
         while time.time() < end_time:
             try:
@@ -248,6 +297,21 @@ def api_command():
         except (TypeError, ValueError):
             value = 0
 
+        raw_targets = message.get("targets")
+        if raw_targets is None:
+            target_ids = None
+        elif isinstance(raw_targets, str):
+            target_ids = [raw_targets]
+        else:
+            target_ids = list(raw_targets)
+
+        if target_ids is not None and len(target_ids) == 0:
+            return jsonify({"error": "no valid targets"}), 400
+
+        target_ips = resolve_target_ips(target_ids)
+        if not target_ips:
+            return jsonify({"error": "no valid targets"}), 400
+
         sig_id = SIGNAL_MAP.get(name)
         if sig_id is None:
             return jsonify({"error": "unknown signal"}), 400
@@ -266,8 +330,10 @@ def api_command():
         sign = _calc_binary_sign(payload)
         packet = payload + sign
 
-        udp_sock.sendto(packet, (PORTENTA_IP, PORTENTA_PORT))
-        return jsonify({"status": "sent"})
+        for ip in target_ips:
+            udp_sock.sendto(packet, (ip, PORTENTA_PORT))
+
+        return jsonify({"status": "sent", "targets": target_ips})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
@@ -282,15 +348,31 @@ def api_get_signal():
         if sig_id is None:
             return jsonify({"error": "unknown signal"}), 400
 
+        raw_targets = message.get("targets")
+        if raw_targets is None:
+            target_ids = None
+        elif isinstance(raw_targets, str):
+            target_ids = [raw_targets]
+        else:
+            target_ids = list(raw_targets)
+
+        if target_ids is not None and len(target_ids) == 0:
+            return jsonify({"error": "no valid targets"}), 400
+
+        target_ips = resolve_target_ips(target_ids)
+        if not target_ips:
+            return jsonify({"error": "no valid targets"}), 400
+
         uid = os.urandom(4)
         sig_type = 0x20  # GET
         value_bytes = struct.pack('>f', 0.0)
         payload = uid + bytes([sig_id, sig_type]) + value_bytes
         sign = _calc_binary_sign(payload)
         packet = payload + sign
-        print(f"[API] Sending GET for {name} (id=0x{sig_id:02X})")
-        udp_sock.sendto(packet, (PORTENTA_IP, PORTENTA_PORT))
-        return jsonify({"status": "sent"})
+        print(f"[API] Sending GET for {name} (id=0x{sig_id:02X}) to {target_ips}")
+        for ip in target_ips:
+            udp_sock.sendto(packet, (ip, PORTENTA_PORT))
+        return jsonify({"status": "sent", "targets": target_ips})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
@@ -311,7 +393,7 @@ def api_upload_config():
 @app.route("/waveform")
 def waveform_page():
     """Simple page for editing waveform parameters."""
-    return render_template("waveform.html")
+    return render_template("waveform.html", devices=DEVICES)
 
 
 

--- a/Client Interface/static/main.js
+++ b/Client Interface/static/main.js
@@ -6,6 +6,17 @@ let logBuffer = [];
 let uiReady = false;
 let pendingUpdates = [];
 
+const deviceInfo = window.DEVICE_INFO || {};
+const allDeviceIds = Object.keys(deviceInfo);
+const selectedDevices = new Set();
+const deviceValues = {};
+const deviceModes = {};
+const deviceStatus = {};
+const DEVICE_OFFLINE_TIMEOUT_MS = 8000;
+let trackedSignals = [];
+const signalDisplayMap = {};
+const valueDefinitions = {};
+
 // --- WebSocket Handlers ---
 socket.on("connect", () => console.log("[WS]  Connected to Socket.IO server"));
 socket.on("disconnect", () => console.warn("[WS]  Disconnected from Socket.IO server"));
@@ -21,95 +32,476 @@ socket.on("update_value", (data) => {
 
 socket.on("log_entry", (entry) => handleLogEntry(entry));
 
-/**
- * UPDATED: This function now controls the header border, the mode text,
- * and enables/disables remote-only command buttons.
- * @param {string|number} value The mode value from the server.
- */
-function updateModeIndicator(value) {
+function getDeviceLabel(deviceId) {
+  const info = deviceInfo[deviceId];
+  return info ? info.label : deviceId;
+}
+
+function getSelectedDeviceOrder() {
+  return Array.from(selectedDevices).sort((a, b) => getDeviceLabel(a).localeCompare(getDeviceLabel(b)));
+}
+
+function getDeviceStatus(deviceId) {
+  if (!deviceStatus[deviceId]) {
+    deviceStatus[deviceId] = { online: false, lastSeen: 0 };
+  }
+  return deviceStatus[deviceId];
+}
+
+function getModeLabel(deviceId) {
+  const status = getDeviceStatus(deviceId);
+  if (!status.online) return "--";
+  const modeValue = parseFloat(deviceModes[deviceId]);
+  if (Number.isNaN(modeValue)) return "Pending";
+  return modeValue >= 0.5 ? "Remote" : "Local";
+}
+
+function getStatusText(deviceId) {
+  const status = getDeviceStatus(deviceId);
+  return status.online ? "Online" : "Offline";
+}
+
+function updateDeviceRowState(deviceId) {
+  const status = getDeviceStatus(deviceId);
+  const table = document.getElementById("device-values-table");
+  if (!table) return;
+  const row = table.querySelector(`tr[data-device-row="${deviceId}"]`);
+  if (!row) return;
+  row.classList.toggle("offline", !status.online);
+  const statusCell = row.querySelector(`td[data-status-for="${deviceId}"]`);
+  if (statusCell) {
+    statusCell.textContent = getStatusText(deviceId);
+  }
+  const modeCell = row.querySelector(`td[data-mode-for="${deviceId}"]`);
+  if (modeCell) {
+    modeCell.textContent = getModeLabel(deviceId);
+  }
+}
+
+function updateAllDeviceRowStates() {
+  allDeviceIds.forEach(updateDeviceRowState);
+}
+
+function updateDeviceRowInfo(deviceId) {
+  const table = document.getElementById("device-values-table");
+  if (!table) return;
+  const labelCell = table.querySelector(`td[data-label-for="${deviceId}"]`);
+  if (labelCell) {
+    labelCell.textContent = getDeviceLabel(deviceId);
+  }
+  const ipCell = table.querySelector(`td[data-ip-for="${deviceId}"]`);
+  if (ipCell) {
+    const info = deviceInfo[deviceId];
+    ipCell.textContent = info?.ip || "--";
+  }
+}
+
+function updateDeviceCardStatus(deviceId) {
+  const status = getDeviceStatus(deviceId);
+  const indicator = document.querySelector(`.status-indicator[data-status-indicator="${deviceId}"]`);
+  const statusText = document.querySelector(`.status-text[data-status-text="${deviceId}"]`);
+  const modeText = document.querySelector(`.status-mode[data-status-mode="${deviceId}"]`);
+
+  if (indicator) {
+    indicator.classList.toggle("online", status.online);
+    indicator.classList.toggle("offline", !status.online);
+  }
+
+  if (statusText) {
+    statusText.textContent = getStatusText(deviceId);
+  }
+
+  if (modeText) {
+    modeText.textContent = `Mode: ${getModeLabel(deviceId)}`;
+  }
+}
+
+function setDeviceOnline(deviceId) {
+  const status = getDeviceStatus(deviceId);
+  status.online = true;
+  status.lastSeen = Date.now();
+  updateDeviceCardStatus(deviceId);
+  updateDeviceRowState(deviceId);
+  updateModeIndicator();
+  updateCommandButtonStates();
+}
+
+function setDeviceOffline(deviceId) {
+  const status = getDeviceStatus(deviceId);
+  if (!status.online) return;
+  status.online = false;
+  status.lastSeen = Date.now();
+  updateDeviceCardStatus(deviceId);
+  updateDeviceRowState(deviceId);
+  updateModeIndicator();
+  updateCommandButtonStates();
+}
+
+function checkDeviceTimeouts() {
+  const now = Date.now();
+  allDeviceIds.forEach((deviceId) => {
+    const status = getDeviceStatus(deviceId);
+    if (!status.online) return;
+    if (now - status.lastSeen > DEVICE_OFFLINE_TIMEOUT_MS) {
+      setDeviceOffline(deviceId);
+    }
+  });
+}
+
+function updateModeIndicator() {
   const indicator = document.getElementById("mode-indicator");
   const header = document.querySelector("header");
   if (!indicator || !header) return;
 
-  const num = parseFloat(value);
-  if (isNaN(num) || num < 0) {
-    indicator.textContent = "Mode: Unknown";
+  if (selectedDevices.size === 0) {
+    indicator.textContent = "Mode: Select target(s)";
     indicator.classList.remove("remote", "local");
     header.classList.remove("mode-remote", "mode-local");
     return;
   }
 
-  const isRemote = num >= 0.5;
+  const selectedOrder = getSelectedDeviceOrder();
+  const remoteDevices = [];
+  const localDevices = [];
+  const pendingDevices = [];
+  const offlineDevices = [];
 
-  // Update text and classes for text color
-  indicator.textContent = isRemote ? "Remote Mode" : "Local Mode";
-  indicator.classList.toggle("remote", isRemote);
-  indicator.classList.toggle("local", !isRemote);
+  selectedOrder.forEach((deviceId) => {
+    const label = getDeviceLabel(deviceId);
+    const status = getDeviceStatus(deviceId);
 
-  // Update header class to control the border color
-  header.classList.toggle("mode-remote", isRemote);
-  header.classList.toggle("mode-local", !isRemote);
+    if (!status.online) {
+      offlineDevices.push(label);
+      return;
+    }
 
-  // Disable buttons that are not 'get' requests when not in remote mode
-  document.querySelectorAll(".btn-command").forEach(btn => {
+    const modeValue = parseFloat(deviceModes[deviceId]);
+
+    if (Number.isNaN(modeValue)) {
+      pendingDevices.push(label);
+    } else if (modeValue >= 0.5) {
+      remoteDevices.push(label);
+    } else {
+      localDevices.push(label);
+    }
+  });
+
+  const segments = [];
+  if (remoteDevices.length) segments.push(`Remote: ${remoteDevices.join(", ")}`);
+  if (localDevices.length) segments.push(`Local: ${localDevices.join(", ")}`);
+  if (pendingDevices.length) segments.push(`Pending: ${pendingDevices.join(", ")}`);
+  if (offlineDevices.length) segments.push(`Offline: ${offlineDevices.join(", ")}`);
+
+  if (!segments.length) {
+    indicator.textContent = "Mode: Awaiting data...";
+    indicator.classList.remove("remote", "local");
+    header.classList.remove("mode-remote", "mode-local");
+    return;
+  }
+
+  indicator.textContent = `Modes — ${segments.join(" | ")}`;
+
+  const allRemote = remoteDevices.length && !localDevices.length && !pendingDevices.length;
+  const allLocal = localDevices.length && !remoteDevices.length && !pendingDevices.length;
+
+  indicator.classList.toggle("remote", allRemote);
+  indicator.classList.toggle("local", allLocal);
+
+  if (allRemote) {
+    header.classList.add("mode-remote");
+    header.classList.remove("mode-local");
+  } else if (allLocal) {
+    header.classList.add("mode-local");
+    header.classList.remove("mode-remote");
+  } else {
+    header.classList.remove("mode-remote", "mode-local");
+    indicator.classList.remove("remote", "local");
+  }
+}
+
+function updateCommandButtonStates() {
+  const buttons = document.querySelectorAll("button.btn-command");
+  const hasSelection = selectedDevices.size > 0;
+  const selectedOrder = getSelectedDeviceOrder();
+  const allRemote = hasSelection && selectedOrder.every((deviceId) => {
+    const status = getDeviceStatus(deviceId);
+    if (!status.online) return false;
+    const modeValue = parseFloat(deviceModes[deviceId]);
+    return !Number.isNaN(modeValue) && modeValue >= 0.5;
+  });
+
+  buttons.forEach((btn) => {
     const name = btn.dataset.name;
     const mode = btn.dataset.mode || "set";
-    // Any button that is not a 'get' request and isn't the mode switch
-    // itself is considered a remote-only action.
-    if (name !== "mode_set" && mode !== "get") {
-      btn.disabled = !isRemote;
+
+    if (!name) {
+      btn.disabled = false;
+      return;
     }
+
+    const isGet = mode === "get";
+    const isModeCommand = name === "mode_set";
+
+    if (!hasSelection) {
+      btn.disabled = true;
+      return;
+    }
+
+    if (isGet || isModeCommand) {
+      btn.disabled = false;
+      return;
+    }
+
+    btn.disabled = !allRemote;
   });
 }
 
-function updateSpanDisplay(span, value) {
-  const valNum = typeof value === "number" ? value : parseFloat(value);
-  const upperLimit = parseFloat(span.dataset.upperOverrideVal);
-  const lowerLimit = parseFloat(span.dataset.lowerOverrideVal);
-  const fmt = span.dataset.displayFormat || "";
+function formatValueWithFormat(value, fmt) {
+  const formatStr = typeof fmt === "string" ? fmt : "";
+  const numericValue = typeof value === "number" ? value : parseFloat(value);
 
-  let newTextContent;
-  if (fmt.toLowerCase() === "ascii") {
-    const intVal = Math.floor(valNum);
+  if (!Number.isFinite(numericValue)) {
+    if (value === null || value === undefined || value === "") {
+      return "--";
+    }
+    return String(value);
+  }
+
+  if (formatStr.toLowerCase() === "ascii") {
+    const intVal = Math.floor(numericValue);
     const bytes = [(intVal >> 24) & 0xff, (intVal >> 16) & 0xff, (intVal >> 8) & 0xff, intVal & 0xff];
     const prefix = String.fromCharCode(bytes[0], bytes[1]);
-    newTextContent = prefix + bytes[3].toString().padStart(2, "0") + bytes[2].toString().padStart(2, "0");
-  } else if (fmt.includes("%08X")) {
-    const intVal = Math.floor(valNum);
-    newTextContent = "0x" + intVal.toString(16).toUpperCase().padStart(8, "0");
-  } else {
-    newTextContent = !isNaN(valNum) ? Number(valNum).toFixed(2) : value;
-  }
-  
-  // Only update the DOM if the text has changed
-  if (span.textContent !== newTextContent) {
-    span.textContent = newTextContent;
+    return prefix + bytes[3].toString().padStart(2, "0") + bytes[2].toString().padStart(2, "0");
   }
 
-  let newColor = "black";
-  if (!isNaN(upperLimit) && valNum >= upperLimit) newColor = "red";
-  else if (!isNaN(lowerLimit) && valNum < lowerLimit) newColor = "blue";
-  
+  if (formatStr.includes("%08X")) {
+    const intVal = Math.floor(numericValue);
+    return "0x" + intVal.toString(16).toUpperCase().padStart(8, "0");
+  }
+
+  return Number(numericValue).toFixed(2);
+}
+
+function formatSignalValue(name, value) {
+  const def = valueDefinitions[name] || {};
+  return formatValueWithFormat(value, def.display_format);
+}
+
+function updateSpanDisplay(span, value) {
+  const fmt = span.dataset.displayFormat || "";
+  const formattedText = formatValueWithFormat(value, fmt);
+  if (span.textContent !== formattedText) {
+    span.textContent = formattedText;
+  }
+
+  const numericValue = typeof value === "number" ? value : parseFloat(value);
+  const upperLimit = parseFloat(span.dataset.upperOverrideVal);
+  const lowerLimit = parseFloat(span.dataset.lowerOverrideVal);
+  let newColor = "#111827";
+
+  if (Number.isFinite(numericValue)) {
+    if (Number.isFinite(upperLimit) && numericValue >= upperLimit) {
+      newColor = "red";
+    } else if (Number.isFinite(lowerLimit) && numericValue < lowerLimit) {
+      newColor = "blue";
+    }
+  }
+
   if (span.style.color !== newColor) {
     span.style.color = newColor;
   }
 }
 
 // --- Polling (Uses the dedicated /api/get_signal endpoint) ---
-function sendGetRequestSignal(name) {
+function getActiveTargets(shouldShowError = true) {
+  if (selectedDevices.size === 0) {
+    if (shouldShowError) {
+      showErrorMessage("Select at least one device to send commands.");
+    }
+    return null;
+  }
+  return getSelectedDeviceOrder();
+}
+
+function sendGetRequestSignal(name, targets, suppressError = false) {
+  let targetIds = Array.isArray(targets) ? targets.slice() : null;
+  if (!targetIds || !targetIds.length) {
+    targetIds = getActiveTargets(!suppressError);
+    if (!targetIds) return;
+  }
+
   fetch("/api/get_signal", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, value: 0, do: "get" })
+    body: JSON.stringify({ name, value: 0, do: "get", targets: targetIds })
   })
   .then(res => res.ok ? res.json() : Promise.reject(res.statusText))
-  .catch(err => showError(`Error requesting ${name}: ${err}`));
+  .catch(err => {
+    if (!suppressError) {
+      showErrorMessage(`Error requesting ${name}: ${err}`);
+    }
+  });
 }
 
 function startGetPolling(names, interval = 1000) {
+  if (!names.length || !allDeviceIds.length) return;
   setInterval(() => {
-    names.forEach(name => sendGetRequestSignal(name));
+    names.forEach((name) => sendGetRequestSignal(name, allDeviceIds, true));
   }, interval);
+}
+
+function renderDeviceTable() {
+  const table = document.getElementById("device-values-table");
+  const emptyMessage = document.getElementById("device-table-empty");
+  if (!table || !emptyMessage) return;
+
+  table.innerHTML = "";
+
+  const hasSignals = trackedSignals.length > 0;
+  emptyMessage.style.display = hasSignals ? "none" : "block";
+
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
+  ["Device", "IP", "Status", "Mode"].forEach((heading) => {
+    const th = document.createElement("th");
+    th.textContent = heading;
+    headerRow.appendChild(th);
+  });
+
+  trackedSignals.forEach((signalName) => {
+    const th = document.createElement("th");
+    th.textContent = signalDisplayMap[signalName] || signalName;
+    headerRow.appendChild(th);
+  });
+
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  const sortedDevices = allDeviceIds.slice().sort((a, b) => getDeviceLabel(a).localeCompare(getDeviceLabel(b)));
+
+  sortedDevices.forEach((deviceId) => {
+    const row = document.createElement("tr");
+    row.dataset.deviceRow = deviceId;
+
+    const labelCell = document.createElement("td");
+    labelCell.dataset.labelFor = deviceId;
+    labelCell.textContent = getDeviceLabel(deviceId);
+    row.appendChild(labelCell);
+
+    const ipCell = document.createElement("td");
+    ipCell.dataset.ipFor = deviceId;
+    const info = deviceInfo[deviceId];
+    ipCell.textContent = info?.ip || "--";
+    row.appendChild(ipCell);
+
+    const statusCell = document.createElement("td");
+    statusCell.dataset.statusFor = deviceId;
+    statusCell.textContent = getStatusText(deviceId);
+    row.appendChild(statusCell);
+
+    const modeCell = document.createElement("td");
+    modeCell.dataset.modeFor = deviceId;
+    modeCell.textContent = getModeLabel(deviceId);
+    row.appendChild(modeCell);
+
+    trackedSignals.forEach((signalName) => {
+      const cell = document.createElement("td");
+      cell.dataset.device = deviceId;
+      cell.dataset.signal = signalName;
+      const value = deviceValues[deviceId]?.[signalName];
+      cell.textContent = formatSignalValue(signalName, value);
+      row.appendChild(cell);
+    });
+
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+  updateAllDeviceRowStates();
+}
+
+function updateDeviceTableCell(deviceId, signalName) {
+  const table = document.getElementById("device-values-table");
+  if (!table) return;
+  const cell = table.querySelector(`td[data-device="${deviceId}"][data-signal="${signalName}"]`);
+  if (!cell) return;
+  const value = deviceValues[deviceId]?.[signalName];
+  cell.textContent = formatSignalValue(signalName, value);
+}
+
+function refreshValueGrid() {
+  const selectedOrder = getSelectedDeviceOrder();
+  const primaryDevice = selectedOrder.length === 1 ? selectedOrder[0] : null;
+  const namesToUpdate = trackedSignals.length ? trackedSignals : Object.keys(valueDefinitions);
+
+  namesToUpdate.forEach((signalName) => {
+    const span = document.getElementById(`value-${signalName}`);
+    if (!span) return;
+
+    if (!primaryDevice) {
+      span.textContent = selectedOrder.length ? "—" : "--";
+      span.style.color = "#111827";
+      return;
+    }
+
+    const value = deviceValues[primaryDevice]?.[signalName];
+    if (value === undefined) {
+      span.textContent = "--";
+      span.style.color = "#111827";
+    } else {
+      updateSpanDisplay(span, value);
+    }
+  });
+}
+
+function initializeDeviceSelector() {
+  const checkboxes = document.querySelectorAll(".device-checkbox");
+
+  allDeviceIds.forEach((deviceId) => {
+    if (!deviceValues[deviceId]) {
+      deviceValues[deviceId] = {};
+    }
+  });
+
+  checkboxes.forEach((checkbox) => {
+    const deviceId = checkbox.dataset.device;
+    if (!deviceId) return;
+    const option = checkbox.closest(".device-option");
+
+    const syncState = () => {
+      if (checkbox.checked) {
+        selectedDevices.add(deviceId);
+      } else {
+        selectedDevices.delete(deviceId);
+      }
+      if (option) {
+        option.classList.toggle("selected", checkbox.checked);
+      }
+    };
+
+    getDeviceStatus(deviceId);
+    updateDeviceCardStatus(deviceId);
+    syncState();
+
+    checkbox.addEventListener("change", () => {
+      syncState();
+      if (checkbox.checked && trackedSignals.length) {
+        trackedSignals.forEach((signalName) => sendGetRequestSignal(signalName, [deviceId], true));
+      }
+      if (selectedDevices.size > 0) {
+        clearErrorMessage();
+      }
+      refreshValueGrid();
+      updateModeIndicator();
+      updateCommandButtonStates();
+    });
+  });
+
+  renderDeviceTable();
+  refreshValueGrid();
+  updateModeIndicator();
+  updateCommandButtonStates();
 }
 
 // --- UI Building ---
@@ -118,6 +510,11 @@ function buildUI(displayConfig) {
   container.innerHTML = "";
   document.getElementById('title').textContent = displayConfig.title || 'PSU Control Dashboard';
   document.title = displayConfig.title || 'PSU Control';
+
+  trackedSignals = [];
+  const seenSignals = new Set();
+  Object.keys(signalDisplayMap).forEach((key) => delete signalDisplayMap[key]);
+  Object.keys(valueDefinitions).forEach((key) => delete valueDefinitions[key]);
 
   displayConfig.panels?.forEach((panel) => {
     const panelDiv = document.createElement("div");
@@ -143,41 +540,81 @@ function buildUI(displayConfig) {
       panelDiv.appendChild(buttonGrid);
     }
     if (panel.values?.length > 0) {
-      const valueGrid = document.createElement("div");
-      valueGrid.className = "value-grid";
       panel.values.forEach(val => {
-        const label = document.createElement("div");
-        label.className = "value-label";
-        label.textContent = val.name + ":";
-        const field = document.createElement("div");
-        field.className = "value-field";
-        const span = document.createElement("span");
-        span.id = "value-" + val.name;
-        span.dataset.upperOverrideVal = val.upper_override_val;
-        span.dataset.lowerOverrideVal = val.lower_override_val;
-        span.dataset.displayFormat = val.display_format;
-        field.appendChild(span);
-        valueGrid.appendChild(label);
-        valueGrid.appendChild(field);
-        updateSpanDisplay(span, val.default_value ?? 0);
+        if (val.name && !seenSignals.has(val.name)) {
+          seenSignals.add(val.name);
+          trackedSignals.push(val.name);
+          signalDisplayMap[val.name] = val.label || val.display_name || val.name;
+        }
+
+        if (val.name) {
+          valueDefinitions[val.name] = {
+            display_format: val.display_format,
+            upper_override_val: val.upper_override_val,
+            lower_override_val: val.lower_override_val,
+          };
+        }
       });
-      panelDiv.appendChild(valueGrid);
+
+      const helper = document.createElement("p");
+      helper.className = "panel-helper";
+      helper.textContent = "Live readings for these signals are available in the C&I Status Overview table.";
+      panelDiv.appendChild(helper);
     }
     container.appendChild(panelDiv);
   });
+  renderDeviceTable();
+  refreshValueGrid();
+  updateModeIndicator();
+  updateCommandButtonStates();
+
   uiReady = true;
   pendingUpdates.forEach(applyUpdate);
   pendingUpdates = [];
 }
 
 function applyUpdate(data) {
-  if (data.name === "mode_set") {
-    updateModeIndicator(data.value);
+  const { device, name } = data;
+  if (!device || !name) return;
+
+  const rawValue = data.value;
+  const numericValue = typeof rawValue === "number" ? rawValue : parseFloat(rawValue);
+  const storedValue = Number.isFinite(numericValue) ? numericValue : rawValue;
+
+  if (data.device_label || data.ip) {
+    if (!deviceInfo[device]) {
+      deviceInfo[device] = { label: data.device_label || device, ip: data.ip };
+    } else {
+      if (data.device_label) deviceInfo[device].label = data.device_label;
+      if (data.ip) deviceInfo[device].ip = data.ip;
+    }
+    updateDeviceRowInfo(device);
+    updateDeviceCardStatus(device);
   }
-  const el = document.getElementById("value-" + data.name);
-  if (el) {
-    updateSpanDisplay(el, data.value);
+
+  if (!deviceValues[device]) {
+    deviceValues[device] = {};
   }
+
+  deviceValues[device][name] = storedValue;
+
+  setDeviceOnline(device);
+
+  if (name === "mode_set") {
+    deviceModes[device] = parseFloat(rawValue);
+    updateDeviceCardStatus(device);
+  }
+
+  const selectedOrder = getSelectedDeviceOrder();
+  if (selectedOrder.length === 1 && selectedOrder[0] === device) {
+    const span = document.getElementById("value-" + name);
+    if (span) {
+      updateSpanDisplay(span, storedValue);
+    }
+  }
+
+  updateDeviceTableCell(device, name);
+  updateDeviceRowState(device);
 }
 
 function initialFetchConfig() {
@@ -190,13 +627,14 @@ function initialFetchConfig() {
       if (data.display_config) {
         buildUI(data.display_config);
         const names = data.display_config.panels?.flatMap(p => p.values?.map(v => v.name).filter(Boolean)) || [];
-        startGetPolling(names, 1000);
+        const uniqueNames = [...new Set(names)];
+        startGetPolling(uniqueNames, 1000);
       } else {
-        showError("Invalid config from server");
+        showErrorMessage("Invalid config from server");
       }
     })
     .catch(err => {
-      showError("Failed to fetch config: " + err.message);
+      showErrorMessage("Failed to fetch config: " + err.message);
     });
 }
 
@@ -243,25 +681,37 @@ document.addEventListener("click", (e) => {
 
     // Use the dedicated 'get' function for polling buttons
     if (mode === "get") {
-      sendGetRequestSignal(name);
+      const targets = getActiveTargets();
+      if (!targets) return;
+      sendGetRequestSignal(name, targets);
       return;
     }
+
+    const targets = getActiveTargets();
+    if (!targets) return;
+
+    const numericValue = parseFloat(value ?? "0");
+    const payloadValue = Number.isFinite(numericValue) ? numericValue : 0;
 
     // Use the /api/command endpoint for all other actions
     fetch("/api/command", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, value: parseFloat(value || "0"), do: mode }),
+      body: JSON.stringify({ name, value: payloadValue, do: mode, targets }),
     })
     .then(res => res.json())
     .then(resp => {
-      if (resp.status !== "sent") showError("Command failed");
+      if (resp.status !== "sent") {
+        showErrorMessage("Command failed");
+      } else {
+        clearErrorMessage();
+      }
     })
-    .catch(err => showError("Command error: " + err.message));
+    .catch(err => showErrorMessage("Command error: " + err.message));
   }
 });
 
-function showError(message) {
+function showErrorMessage(message) {
   const err = document.getElementById("error");
   if (err) {
     err.textContent = message;
@@ -271,4 +721,15 @@ function showError(message) {
   }
 }
 
-document.addEventListener("DOMContentLoaded", initialFetchConfig);
+function clearErrorMessage() {
+  const err = document.getElementById("error");
+  if (err) {
+    err.style.display = "none";
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  initializeDeviceSelector();
+  initialFetchConfig();
+  setInterval(checkDeviceTimeouts, 2000);
+});

--- a/Client Interface/templates/index.html
+++ b/Client Interface/templates/index.html
@@ -11,6 +11,9 @@
 
   <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
   
+  <script>
+    window.DEVICE_INFO = {{ devices | tojson }};
+  </script>
   <script src="{{ url_for('static', filename='main.js') }}"></script>
   
   <style>
@@ -77,6 +80,7 @@
       border-bottom: 1px solid var(--border-color);
       padding-bottom: 0.75rem; margin-bottom: 1.5rem;
     }
+    .panel-helper { margin: 0.5rem 0 0; font-size: 0.85rem; color: var(--text-muted-color); font-style: italic; }
 
     .value-grid { display: grid; grid-template-columns: 180px 1fr; gap: 1rem 1.25rem; align-items: center; }
     .value-label { text-align: right; font-weight: 500; color: var(--text-muted-color); font-size: 0.875rem; }
@@ -92,7 +96,31 @@
     .btn-command:hover { background-color: var(--primary-hover-color); transform: translateY(-2px); }
     .btn-command:disabled { background-color: #9ca3af; cursor: not-allowed; transform: none; }
 
-	  .log-box { max-height: 240px; overflow-y: auto; background-color: #0f172a; color: #f1f5f9; font-family: monospace; font-size: 0.85rem; padding: 1rem; border-radius: 8px; border: 1px solid var(--border-color); }
+    .device-selector { display: grid; gap: 0.75rem; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    .device-help { margin-top: 0; margin-bottom: 1.25rem; font-size: 0.95rem; color: var(--text-muted-color); }
+    .device-option { display: flex; align-items: flex-start; gap: 0.75rem; padding: 0.85rem 1rem; border: 1px solid var(--border-color); border-radius: 10px; background: var(--value-bg-color); cursor: pointer; transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease; }
+    .device-option.selected { border-color: var(--primary-color); background: #dbeafe; box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.25); }
+    .device-option input { width: 1.1rem; height: 1.1rem; margin-top: 0.25rem; }
+    .device-card-body { display: flex; flex-direction: column; gap: 0.35rem; }
+    .device-option:hover { border-color: var(--primary-color); background: #eef2ff; }
+    .device-label-text { font-weight: 600; }
+    .device-ip { color: var(--text-muted-color); font-size: 0.8rem; }
+    .device-status-line { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; }
+    .status-indicator { width: 0.65rem; height: 0.65rem; border-radius: 50%; background-color: #9ca3af; box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.1); }
+    .status-indicator.online { background-color: #22c55e; }
+    .status-indicator.offline { background-color: #9ca3af; }
+    .status-text { font-weight: 600; }
+    .status-mode { color: var(--text-muted-color); }
+
+    .table-wrapper { overflow-x: auto; }
+    table.device-table { width: 100%; border-collapse: collapse; }
+    table.device-table thead { background: var(--value-bg-color); }
+    table.device-table th, table.device-table td { padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--border-color); text-align: left; }
+    table.device-table tbody tr:hover { background: #f8fafc; }
+    table.device-table tr.offline { opacity: 0.65; }
+    #device-table-empty { text-align: center; color: var(--text-muted-color); margin: 1rem 0 0; }
+
+    .log-box { max-height: 240px; overflow-y: auto; background-color: #0f172a; color: #f1f5f9; font-family: monospace; font-size: 0.85rem; padding: 1rem; border-radius: 8px; border: 1px solid var(--border-color); }
     .error-message { color: var(--error-text-color); text-align: center; padding: 1rem; background-color: var(--error-bg-color); border: 1px solid var(--error-border-color); border-radius: 8px; font-weight: 500; margin-top: 1rem; }
   </style>
 </head>
@@ -105,6 +133,35 @@
   </header>
   
   <main class="container">
+    <div class="panel" id="device-control-panel">
+      <h3>Target Portenta Boards</h3>
+      <p class="device-help">Checked systems receive the commands from the control panels below. Live status for every C&amp;I appears in the table that follows.</p>
+      <div class="device-selector" id="device-selector">
+        {% for device_id, info in devices.items() %}
+        <label class="device-option" data-device-card="{{ device_id }}">
+          <input type="checkbox" class="device-checkbox" data-device="{{ device_id }}">
+          <div class="device-card-body">
+            <div class="device-label-text">{{ info.label }}</div>
+            <div class="device-ip">{{ info.ip }}</div>
+            <div class="device-status-line">
+              <span class="status-indicator offline" data-status-indicator="{{ device_id }}"></span>
+              <span class="status-text" data-status-text="{{ device_id }}">Offline</span>
+              <span class="status-mode" data-status-mode="{{ device_id }}">Mode: --</span>
+            </div>
+          </div>
+        </label>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="panel" id="device-values-panel">
+      <h3>C&amp;I Status Overview</h3>
+      <div class="table-wrapper">
+        <table id="device-values-table" class="device-table"></table>
+      </div>
+      <p id="device-table-empty">Waiting for display configuration...</p>
+    </div>
+
     <div id="panels"></div>
     <p class="error-message" id="error" style="display:none;"></p>
     <div id="logContainerWrapper" class="panel">

--- a/Client Interface/templates/waveform.html
+++ b/Client Interface/templates/waveform.html
@@ -52,6 +52,23 @@
       border-radius: var(--radius);
       box-shadow: var(--shadow);
     }
+    .selector-card .body { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+    .device-option {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+      background: color-mix(in oklab, var(--panel) 94%, #000 6%);
+      padding: 8px 12px;
+      border-radius: 10px;
+      cursor: pointer;
+      transition: border-color .15s ease, transform .1s ease;
+    }
+    .device-option input { accent-color: var(--accent); }
+    .device-option:hover { border-color: color-mix(in oklab, var(--accent) 40%, var(--border)); transform: translateY(-1px); }
+    .device-option .device-label { font-weight: 600; }
+    .device-option .device-ip { font-size: 12px; color: var(--muted); }
+    .selector-summary { font-size: 13px; color: var(--muted); }
     .card .head { padding: 14px 16px 0; display: flex; align-items: center; justify-content: space-between; }
     .card .body { padding: 16px; }
     .grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px 12px; }
@@ -110,6 +127,25 @@
 </head>
 <body>
   <h1>Waveform Designer</h1>
+
+  <div class="card selector-card">
+    <div class="head">
+      <div class="row">
+        <span class="badgelike">Targets</span>
+        <span class="muted">Select Portenta boards to receive waveform commands</span>
+      </div>
+      <div class="row selector-summary" id="deviceSummary">All devices selected</div>
+    </div>
+    <div class="body">
+      {% for device_id, info in devices.items() %}
+      <label class="device-option">
+        <input type="checkbox" class="device-checkbox" value="{{ device_id }}" data-label="{{ info.label }}" checked>
+        <span class="device-label">{{ info.label }}</span>
+        <span class="device-ip">{{ info.ip }}</span>
+      </label>
+      {% endfor %}
+    </div>
+  </div>
 
   <div class="container">
     <div class="card">
@@ -215,6 +251,7 @@
   <script>
     // ---------- utilities ----------
     const $ = id => document.getElementById(id);
+    const deviceCheckboxes = Array.from(document.querySelectorAll('.device-checkbox'));
     const names = ["t1","th","t2","a1","b1","c1","d1","a2","b2","c2","d2"];
     const MAX_CURRENT = 3000; // hard cap like firmware
 
@@ -384,12 +421,48 @@
       $("yMinMax").textContent = `${yMin.toFixed(3)} A … ${yMax.toFixed(3)} A`;
     }
 
+    function getSelectedTargets() {
+      const checked = deviceCheckboxes.filter(cb => cb.checked).map(cb => cb.value);
+      if (!checked.length) {
+        alert('Select at least one device target.');
+        return null;
+      }
+      return checked;
+    }
+
+    function updateDeviceSummary() {
+      const summary = $('deviceSummary');
+      if (!summary) return;
+      if (!deviceCheckboxes.length) {
+        summary.textContent = 'No devices available';
+        return;
+      }
+      const checked = deviceCheckboxes.filter(cb => cb.checked);
+      if (checked.length === deviceCheckboxes.length) {
+        summary.textContent = 'All devices selected';
+        return;
+      }
+      if (!checked.length) {
+        summary.textContent = 'No devices selected';
+        return;
+      }
+      const labels = checked.map(cb => cb.dataset.label || cb.value);
+      summary.textContent = `Sending to: ${labels.join(', ')}`;
+    }
+
+    deviceCheckboxes.forEach(cb => cb.addEventListener('change', updateDeviceSummary));
+    updateDeviceSummary();
+
     // Send helpers
-    function sendCommand(name, value){
+    function sendCommand(name, value, targets){
+      const payload = { name, value };
+      if (Array.isArray(targets) && targets.length) {
+        payload.targets = targets;
+      }
       return fetch('/api/command', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({name, value})
+        body:JSON.stringify(payload)
       });
     }
 
@@ -400,6 +473,8 @@
 
     async function sendAllValues(withCap=true) {
       const v = readValues();
+      const targets = getSelectedTargets();
+      if (!targets) return;
 
       // Auto-cap coefficients to keep waveform ≤ 3000 A
       if (withCap) {
@@ -415,7 +490,7 @@
         if (n === 't1' || n === 'th' || n === 't2') {
             val /= 1000;
         }
-        await sendCommand(n, val);
+        await sendCommand(n, val, targets);
       }
     }
 
@@ -424,11 +499,15 @@
       await sendAllValues(true);
     });
     $("run").addEventListener("click", async () => {
-      await sendCommand('run_current_wave', 1);
+      const targets = getSelectedTargets();
+      if (!targets) return;
+      await sendCommand('run_current_wave', 1, targets);
     });
     $("sendrun").addEventListener("click", async () => {
       await sendAllValues(true);
-      await sendCommand('run_current_wave', 1);
+      const targets = getSelectedTargets();
+      if (!targets) return;
+      await sendCommand('run_current_wave', 1, targets);
     });
     $("reset").addEventListener("click", () => {
       $("t1").value = 500; $("th").value = 100; $("t2").value = 500;


### PR DESCRIPTION
## Summary
- add live online/offline tracking and per-device mode badges to the selector and overview table
- show every configured signal for all C&I systems in the status table regardless of selection
- remove redundant panel value readouts and add guidance so operators know commands follow the checked boards

## Testing
- python -m compileall 'Client Interface/main.py'

------
https://chatgpt.com/codex/tasks/task_e_68da0a9315508324b27668e4cd49ec48