### PR TITLE
Enforce charge relay gating and update measurement filters

### DIFF
--- a/Arduino Mid Carrier/XC_SW/Config.cpp
+++ b/Arduino Mid Carrier/XC_SW/Config.cpp
@@ -17,7 +17,7 @@ unsigned long WARN_BLINK_INTERVAL_MS = 5000;
 float WARN_VOLTAGE_THRESHOLD = 50.0f;
 
 // --- Control Parameters ---
-float CURRENT_LIMIT_MAX  = 3000.0f;   // Max current in milli amps
+float CURRENT_LIMIT_MAX  = 3600.0f;   // Max current in milli amps
 float OVER_VOLTAGE_LIMIT = 285.0f;  // Disable if output exceeds this
 
 

--- a/Arduino Mid Carrier/XC_SW/IGBT.h
+++ b/Arduino Mid Carrier/XC_SW/IGBT.h
@@ -12,7 +12,8 @@ void init_igbt();
 void update_igbt();
 
 // Read the (active-low) IGBT gate fault input
-bool igbt_fault_active(); 
+bool igbt_fault_active();
+bool igbt_drive_is_low();
 //void update_igbt_ignore()
 
 #endif // IGBT_H

--- a/Arduino Mid Carrier/XC_SW/SerialComms.cpp
+++ b/Arduino Mid Carrier/XC_SW/SerialComms.cpp
@@ -67,7 +67,7 @@ int get_internal_enable_state() { return PowerState::internalEnable ? 1 : 0; }
 int get_external_enable_state() { return PowerState::externalEnable ? 1 : 0; } 
 
 int get_dump_fan_state() { return PowerState::DumpFan ? 1 : 0; }
-int get_dump_relay_state() { return PowerState::DumpRelay ? 1 : 0; } 
+int get_dump_relay_state() { return PowerState::DumpRelay ? 0 : 1; }
 int get_charger_relay_state() { return PowerState::ChargerRelay ? 1 : 0; } 
 int get_scr_trig_state() { return PowerState::ScrTrig ? 1 : 0; }
 int get_scr_inhib_state() { return PowerState::ScrInhib ? 1 : 0; } 
@@ -93,7 +93,7 @@ int process_event_in_uc(const std::string& json_event_std)
     else if (jv.is<int>())          value = jv.as<int>();
     else if (jv.is<const char*>())  value = atof(jv.as<const char*>());
 
-    if (strcmp(name, "curr_set") == 0) {if (value < 0.0f) value = 0.0f; if (value > 3000.0f) value = 3000.0f; PowerState::setCurrent = value; return 1;}
+    if (strcmp(name, "curr_set") == 0) {if (value < 0.0f) value = 0.0f; if (value > 3600.0f) value = 3600.0f; PowerState::setCurrent = value; return 1;}
     else if (strcmp(name, "volt_set") == 0) {if (value < 0.0f) value = 0.0f; if (value > 285.0f) value = 285.0f; PowerState::setVoltage = value; return 1;}
     else if (strcmp(name, "inter_enable") == 0) { PowerState::internalEnable = (value != 0.0f); return 1; }
     else if (strcmp(name, "extern_enable") == 0) { PowerState::externalEnable = (value != 0.0f); return 1; }


### PR DESCRIPTION
## Summary
- gate current waveform execution on the charge relay state so waves only run with the charger disabled
- sample probe current only when the IGBT gate is low, raise the SCR trigger limit, and add simple IIR filtering for current and voltage measurements
- invert the displayed dump relay state and increase the maximum current limit to 3600 A

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca5471cf0832492737d09a950c122